### PR TITLE
Update ee-bt_wi-fi_autologin_service (v7) - Add functionality for cha…

### DIFF
--- a/ee-bt_wi-fi_autologin_service (v7)
+++ b/ee-bt_wi-fi_autologin_service (v7)
@@ -30,6 +30,11 @@ ACCOUNTTYPE=$(grep '#ACCTYPE=' /etc/rc.local | sed -r 's/^.{9}//')
 USERNAME=$(grep '#USERNAME=' /etc/rc.local | sed -r 's/^.{10}//')
 PASSWORD=$(grep '#PASSWORD=' /etc/rc.local | sed -r 's/^.{10}//')
 
+#->->->-> EE WIFI AUTH API ENDPOINT ADDRESSES <-<-<-<-#
+### If this value is unset, we will use nslookup to pull the address
+ENDPOINT=$(grep '#ENDPOINT=' /etc/rc.local | sed -r 's/^.{12}//')
+DNSSERVER=$(grep '#DNSSERVER=' /etc/rc.local | sed -r 's/^.{11}//')
+
 #->->->-> OPTIONAL SETTINGS <-<-<-<-#
 
 LOGSIZE=$(grep '#LOGSIZE=' /etc/rc.local | sed -r 's/^.{9}//')
@@ -85,7 +90,13 @@ stop() {
 	rm $PIDFILELOGIN
 	rm $PIDFILECUTLOG
 	rm $PIDFILETLS
-	wget --no-check-certificate -T 2 -O /dev/null 'https://192.168.23.21:8443/accountLogoff/home?confirmed=true'
+
+	if [ -z "$ENDPOINT" ]; 
+	then
+		ENDPOINT=`nslookup ee-wifi.ee.co.uk $DNSSERVER | awk -F ': ' 'NR==6 { print $2 } '`
+	fi
+
+	wget --no-check-certificate -T 2 -O /dev/null "https://$ENDPOINT/accountLogoff/home?confirmed=true"
 	logger -t BTWi-fi_Autologin_Service "$(date) BTWi-fi Autologin Service Stopped Manually (Or Reboot)"
 	echo "$(date) SERVICE STOP! BTWi-fi Autologin Service Stopped Manually (Or Reboot)" >> "$LOGPATH"
 }
@@ -178,25 +189,30 @@ while true
 do
 if [ -e /tmp/tls_completed ]
 then
-	if ! ping -c 1 -W 1 "$PING1" 2>/dev/null >/dev/null	 
+	if [ -z "$ENDPOINT" ]; 
 	then
-		if ! ping -c 1 -W 1 "$PING2" 2>/dev/null >/dev/null			 
+		ENDPOINT=`nslookup ee-wifi.ee.co.uk $DNSSERVER | awk -F ': ' 'NR==6 { print $2 } '`
+	fi
+
+	if ! ping -c 1 -W 1 "$PING1" 2>/dev/null >/dev/null
+	then
+		if ! ping -c 1 -W 1 "$PING2" 2>/dev/null >/dev/null
 		then
 			if [ "$ACCOUNTTYPE" = "1" ]
 			then
 				logger -t BTWi-fi_Autologin_Service "$(date) Offline, attempting login URL 1 (BT Home Broadband Account)"
 				echo "$(date) Offline, attempting login URL 1 (BT Home Broadband Account)" >> "$LOGPATH"
-				wget --no-check-certificate -T 2 -O /dev/null --post-data "username=$USERNAME&password=$PASSWORD" 'https://192.168.23.21:8443/tbbLogon'
+				wget --no-check-certificate -T 2 -O /dev/null --post-data "username=$USERNAME&password=$PASSWORD" "https://$ENDPOINT/tbbLogon"
 			elif [ "$ACCOUNTTYPE" = "2" ]
 			then
 				logger -t BTWi-fi_Autologin_Service "$(date) Offline, attempting login URL 2 (BT Buisness Broadband Account)"
 				echo "$(date) Offline, attempting login URL 2 (BT Buisness Broadband Account)" >> "$LOGPATH"
-				wget --no-check-certificate -T 2 -O /dev/null --post-data "username=$USERNAME&password=$PASSWORD" 'https://192.168.23.21:8443/ante?partnerNetwork=btb'
+				wget --no-check-certificate -T 2 -O /dev/null --post-data "username=$USERNAME&password=$PASSWORD" "https://$ENDPOINT/ante?partnerNetwork=btb"
 			elif [ "$ACCOUNTTYPE" = "3" ]
 			then
 				logger -t BTWi-fi_Autologin_Service "$(date) Offline, attempting login URL 3 (BT Wi-Fi Account)"
 				echo "$(date) Offline, attempting login URL 3 (BT Wi-Fi Account)" >> "$LOGPATH"
-				wget --no-check-certificate -T 2 -O /dev/null --post-data "username=$USERNAME&password=$PASSWORD" 'https://192.168.23.21:8443/ante'
+				wget --no-check-certificate -T 2 -O /dev/null --post-data "username=$USERNAME&password=$PASSWORD" "https://$ENDPOINT/ante"
 			fi
 		fi
 	fi


### PR DESCRIPTION
Add functionality for changing API endpoints

Changes:
1) Added $ENDPOINT and $DNSSERVER vars

2) Added logic to check if $ENDPOINT is set manually, and if not, use nslookup to get the current IP

3) Send API requests using $ENDPOINT var

4) EE Wifi no longer uses :8443 for API calls, so the the port has been omitted from URLS